### PR TITLE
Replace framer motion for website loading

### DIFF
--- a/src/components/HeroBanner.tsx
+++ b/src/components/HeroBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion } from "framer-motion";
+import { motion } from "@/lib/safe-motion";
 import { useNavigate } from 'react-router-dom';
 import { ArrowRight, BookOpen, Store } from 'lucide-react';
 import AnimatedButton from './ui/AnimatedButton';

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from '@/lib/safe-motion';
 import ModernHeader from './ModernHeader';
 import Footer from './Footer';
 import Breadcrumb from './Breadcrumb';

--- a/src/components/ModernHeader.tsx
+++ b/src/components/ModernHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence } from '@/lib/safe-motion';
 import { 
   Search, 
   Menu, 

--- a/src/components/ModernProductCard.tsx
+++ b/src/components/ModernProductCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from '@/lib/safe-motion';
 import { Heart, ShoppingCart, Star, Eye, Plus } from 'lucide-react';
 import AnimatedButton from './ui/AnimatedButton';
 import AnimatedCard from './ui/AnimatedCard';

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence } from '@/lib/safe-motion';
 import { Sun, Moon, Monitor } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 

--- a/src/components/ui/AnimatedButton.tsx
+++ b/src/components/ui/AnimatedButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion, MotionProps } from 'framer-motion';
+import { motion, MotionProps } from '@/lib/safe-motion';
 import { LucideIcon } from 'lucide-react';
 
 interface AnimatedButtonProps extends Omit<MotionProps, 'children'> {

--- a/src/components/ui/AnimatedCard.tsx
+++ b/src/components/ui/AnimatedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion, MotionProps } from 'framer-motion';
+import { motion, MotionProps } from '@/lib/safe-motion';
 
 interface AnimatedCardProps extends Omit<MotionProps, 'children'> {
   children: React.ReactNode;

--- a/src/lib/safe-motion.tsx
+++ b/src/lib/safe-motion.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+// Safe, no-op motion shim to allow the app to render without framer-motion
+// Exports a "motion" object with intrinsic elements that ignore animation props
+// and an AnimatePresence that simply renders children.
+
+export type MotionProps = any;
+
+type AnyProps = Record<string, unknown> & { children?: React.ReactNode };
+
+function createNoopComponent(tag: string) {
+	const Component = React.forwardRef<unknown, AnyProps>((props, ref) => {
+		// Strip out common motion props to avoid React DOM warnings
+		const {
+			initial: _initial,
+			animate: _animate,
+			exit: _exit,
+			whileHover: _whileHover,
+			whileTap: _whileTap,
+			transition: _transition,
+			layoutId: _layoutId,
+			...rest
+		} = props as AnyProps;
+		return React.createElement(tag as any, { ...rest, ref } as any);
+	});
+	Component.displayName = `motion.${tag}`;
+	return Component;
+}
+
+export const motion: Record<string, React.ComponentType<any>> = new Proxy({}, {
+	get: (_target, key) => {
+		const tag = String(key);
+		return createNoopComponent(tag);
+	}
+}) as any;
+
+export const AnimatePresence: React.FC<{ children?: React.ReactNode } & AnyProps> = ({ children }) => {
+	return <>{children}</>;
+};
+

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -10,7 +10,7 @@ import { Helmet } from 'react-helmet-async';
 import { z } from 'zod';
 import { useToast } from '@/hooks/use-toast';
 import { Mail, Lock, User as UserIcon } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { motion } from '@/lib/safe-motion';
 
 const emailSchema = z.string().email();
 const passwordSchema = z.string().min(6);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { motion } from "framer-motion";
+import { motion } from "@/lib/safe-motion";
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 


### PR DESCRIPTION
Replace `framer-motion` with a no-op `safe-motion` shim to fix website loading errors.

The website was failing to load due to `framer-motion` errors. This PR introduces a `safe-motion` shim that mimics `framer-motion`'s API but ignores all animation props, allowing the site to render without the dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-fba9f960-395e-45a7-9f6b-b29f99814eba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fba9f960-395e-45a7-9f6b-b29f99814eba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

