### PR TITLE
Debug blank login page after seller signup

### DIFF
--- a/src/components/ModernHeader.tsx
+++ b/src/components/ModernHeader.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from '@/lib/safe-motion';
+import { api } from '@/lib/api';
 import { 
   Search, 
   Menu, 
@@ -52,9 +53,12 @@ const ModernHeader: React.FC = () => {
 
   const checkUserAuth = async () => {
     try {
-      const { data, error } = await window.ezsite.apis.getUserInfo();
+      const getUserInfo = window.ezsite?.apis?.getUserInfo;
+      const { data, error } = getUserInfo
+        ? await getUserInfo()
+        : await api.auth.me();
       if (!error && data) {
-        setUser(data);
+        setUser(data as any);
       }
     } catch (error) {
       console.error('Auth check error:', error);
@@ -82,7 +86,8 @@ const ModernHeader: React.FC = () => {
 
   const handleLogout = async () => {
     try {
-      const { error } = await window.ezsite.apis.logout();
+      const logout = window.ezsite?.apis?.logout;
+      const { error } = logout ? await logout() : await api.auth.logout();
       if (!error) {
         setUser(null);
         window.location.href = '/';


### PR DESCRIPTION
Safely fetch user info and handle logout in `ModernHeader` to prevent a blank login page when `window.ezsite` is not yet initialized.

The `ModernHeader` component was attempting to call `window.ezsite.apis.getUserInfo()` and `window.ezsite.apis.logout()` directly during its initial render. This could lead to a `TypeError` and a blank page if `window.ezsite` or its `apis` property had not yet been fully initialized. The fix introduces optional chaining and falls back to the `api` module's auth methods, ensuring the component renders robustly.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f601650-ab57-44d6-83ed-fd7601f3395d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f601650-ab57-44d6-83ed-fd7601f3395d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

